### PR TITLE
Add extract package used for parsing semantic event log info

### DIFF
--- a/ccel/extract.go
+++ b/ccel/extract.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-eventlog/common"
-	"github.com/google/go-eventlog/internal/eventparse"
+	"github.com/google/go-eventlog/extract"
 	pb "github.com/google/go-eventlog/proto/state"
 	"github.com/google/go-eventlog/register"
 	"github.com/google/go-eventlog/tcg"
@@ -74,11 +74,11 @@ func ExtractFirmwareLogState(acpiTableFile []byte, rawEventLog []byte, rtmrBank 
 		3       RTMR[2]  8-15
 		4       RTMR[3]  n/a
 	*/
-	sbState, err := eventparse.GetSecureBootState(events, eventparse.RTMRRegisterConfig)
+	sbState, err := extract.GetSecureBootState(events, extract.RTMRRegisterConfig)
 	if err != nil {
 		joined = errors.Join(joined, err)
 	}
-	efiState, err := eventparse.GetEfiState(cryptoHash, events, eventparse.RTMRRegisterConfig)
+	efiState, err := extract.GetEfiState(cryptoHash, events, extract.RTMRRegisterConfig)
 
 	if err != nil {
 		joined = errors.Join(joined, err)
@@ -87,12 +87,12 @@ func ExtractFirmwareLogState(acpiTableFile []byte, rawEventLog []byte, rtmrBank 
 	var grub *pb.GrubState
 	var kernel *pb.LinuxKernelState
 	if opts.Loader == common.GRUB {
-		grub, err = eventparse.GetGrubStateForRTMRLog(cryptoHash, events, eventparse.RTMRRegisterConfig)
+		grub, err = extract.GetGrubStateForRTMRLog(cryptoHash, events, extract.RTMRRegisterConfig)
 
 		if err != nil {
 			joined = errors.Join(joined, err)
 		}
-		kernel, err = eventparse.GetLinuxKernelStateFromGRUB(grub)
+		kernel, err = extract.GetLinuxKernelStateFromGRUB(grub)
 		if err != nil {
 			joined = errors.Join(joined, err)
 		}

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -12,8 +12,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// Package eventparse has tools for extracting boot and runtime information from measurements.
-package eventparse
+// Package extract has tools for extracting boot and runtime information from measurements.
+package extract
 
 import (
 	"bytes"

--- a/extract/pcr.go
+++ b/extract/pcr.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package eventparse
+package extract
 
 import (
 	"bytes"

--- a/extract/registerconfig.go
+++ b/extract/registerconfig.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package eventparse
+package extract
 
 import (
 	"github.com/google/go-eventlog/tcg"

--- a/extract/rtmr.go
+++ b/extract/rtmr.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package eventparse
+package extract
 
 import (
 	"bytes"

--- a/extract/secureboot.go
+++ b/extract/secureboot.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package eventparse
+package extract
 
 import (
 	"bytes"

--- a/extract/secureboot_test.go
+++ b/extract/secureboot_test.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package eventparse_test
+package extract_test
 
 import (
 	"crypto"
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-eventlog/internal/eventparse"
+	"github.com/google/go-eventlog/extract"
 	"github.com/google/go-eventlog/internal/testutil"
 	"github.com/google/go-eventlog/proto/state"
 	"github.com/google/go-eventlog/register"
@@ -29,7 +29,7 @@ import (
 )
 
 func TestSecureBoot(t *testing.T) {
-	data, err := os.ReadFile("../../testdata/legacydata/windows_gcp_shielded_vm.json")
+	data, err := os.ReadFile("../testdata/legacydata/windows_gcp_shielded_vm.json")
 	if err != nil {
 		t.Fatalf("reading test data: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestSecureBoot(t *testing.T) {
 		t.Fatalf("validating event log: %v", err)
 	}
 
-	sbState, err := eventparse.ParseSecurebootState(events, eventparse.TPMRegisterConfig)
+	sbState, err := extract.ParseSecurebootState(events, extract.TPMRegisterConfig)
 	if err != nil {
 		t.Fatalf("ExtractSecurebootState() failed: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestSecureBoot(t *testing.T) {
 
 // See: https://github.com/google/go-attestation/issues/157
 func TestSecureBootBug157(t *testing.T) {
-	raw, err := os.ReadFile("../../testdata/legacydata/sb_cert_eventlog")
+	raw, err := os.ReadFile("../testdata/legacydata/sb_cert_eventlog")
 	if err != nil {
 		t.Fatalf("reading test data: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestSecureBootBug157(t *testing.T) {
 		t.Fatalf("failed to verify log: %v", err)
 	}
 
-	sbs, err := eventparse.ParseSecurebootState(events, eventparse.TPMRegisterConfig)
+	sbs, err := extract.ParseSecurebootState(events, extract.TPMRegisterConfig)
 	if err != nil {
 		t.Fatalf("failed parsing secureboot state: %v", err)
 	}
@@ -145,7 +145,7 @@ func b64MustDecode(input string) []byte {
 }
 
 func TestSecureBootOptionRom(t *testing.T) {
-	raw, err := os.ReadFile("../../testdata/legacydata/option_rom_eventlog")
+	raw, err := os.ReadFile("../testdata/legacydata/option_rom_eventlog")
 	if err != nil {
 		t.Fatalf("reading test data: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestSecureBootOptionRom(t *testing.T) {
 		t.Errorf("failed to verify log: %v", err)
 	}
 
-	sbs, err := eventparse.ParseSecurebootState(events, eventparse.TPMRegisterConfig)
+	sbs, err := extract.ParseSecurebootState(events, extract.TPMRegisterConfig)
 	if err != nil {
 		t.Errorf("failed parsing secureboot state: %v", err)
 	}
@@ -181,13 +181,13 @@ func TestSecureBootOptionRom(t *testing.T) {
 	if got, want := len(sbs.DriverLoadSourceHints), 1; got != want {
 		t.Fatalf("len(sbs.DriverLoadSourceHints) = %d, want %d", got, want)
 	}
-	if got, want := sbs.DriverLoadSourceHints[0], eventparse.PciMmioSource; got != want {
+	if got, want := sbs.DriverLoadSourceHints[0], extract.PciMmioSource; got != want {
 		t.Errorf("sbs.DriverLoadSourceHints[0] = %v, want %v", got, want)
 	}
 }
 
 func TestSecureBootEventLogUbuntu(t *testing.T) {
-	data, err := os.ReadFile("../../testdata/legacydata/ubuntu_2104_shielded_vm_no_secure_boot_eventlog")
+	data, err := os.ReadFile("../testdata/legacydata/ubuntu_2104_shielded_vm_no_secure_boot_eventlog")
 	if err != nil {
 		t.Fatalf("reading test data: %v", err)
 	}
@@ -199,14 +199,14 @@ func TestSecureBootEventLogUbuntu(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verifying event log: %v", err)
 	}
-	_, err = eventparse.ParseSecurebootState(evts, eventparse.TPMRegisterConfig)
+	_, err = extract.ParseSecurebootState(evts, extract.TPMRegisterConfig)
 	if err != nil {
 		t.Errorf("parsing sb state: %v", err)
 	}
 }
 
 func TestSecureBootEventLogFedora36(t *testing.T) {
-	data, err := os.ReadFile("../../testdata/legacydata/coreos_36_shielded_vm_no_secure_boot_eventlog")
+	data, err := os.ReadFile("../testdata/legacydata/coreos_36_shielded_vm_no_secure_boot_eventlog")
 	if err != nil {
 		t.Fatalf("reading test data: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestSecureBootEventLogFedora36(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verifying event log: %v", err)
 	}
-	_, err = eventparse.ParseSecurebootState(evts, eventparse.TPMRegisterConfig)
+	_, err = extract.ParseSecurebootState(evts, extract.TPMRegisterConfig)
 	if err != nil {
 		t.Errorf("parsing sb state: %v", err)
 	}

--- a/extract/util.go
+++ b/extract/util.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package eventparse
+package extract
 
 import (
 	"bytes"

--- a/tpmeventlog/extract.go
+++ b/tpmeventlog/extract.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 
 	"github.com/google/go-eventlog/common"
-	"github.com/google/go-eventlog/internal/eventparse"
+	"github.com/google/go-eventlog/extract"
 	pb "github.com/google/go-eventlog/proto/state"
 	"github.com/google/go-eventlog/register"
 	"github.com/google/go-eventlog/tcg"
@@ -58,15 +58,15 @@ func ExtractFirmwareLogState(rawEventLog []byte, pcrBank register.PCRBank, opts 
 		return nil, err
 	}
 
-	platform, err := eventparse.GetPlatformState(cryptoHash, events)
+	platform, err := extract.GetPlatformState(cryptoHash, events)
 	if err != nil {
 		joined = errors.Join(joined, err)
 	}
-	sbState, err := eventparse.GetSecureBootState(events, eventparse.TPMRegisterConfig)
+	sbState, err := extract.GetSecureBootState(events, extract.TPMRegisterConfig)
 	if err != nil {
 		joined = errors.Join(joined, err)
 	}
-	efiState, err := eventparse.GetEfiState(cryptoHash, events, eventparse.TPMRegisterConfig)
+	efiState, err := extract.GetEfiState(cryptoHash, events, extract.TPMRegisterConfig)
 	if err != nil {
 		joined = errors.Join(joined, err)
 	}
@@ -74,11 +74,11 @@ func ExtractFirmwareLogState(rawEventLog []byte, pcrBank register.PCRBank, opts 
 	var grub *pb.GrubState
 	var kernel *pb.LinuxKernelState
 	if opts.Loader == common.GRUB {
-		grub, err = eventparse.GetGrubStateForTPMLog(cryptoHash, events)
+		grub, err = extract.GetGrubStateForTPMLog(cryptoHash, events)
 		if err != nil {
 			joined = errors.Join(joined, err)
 		}
-		kernel, err = eventparse.GetLinuxKernelStateFromGRUB(grub)
+		kernel, err = extract.GetLinuxKernelStateFromGRUB(grub)
 		if err != nil {
 			joined = errors.Join(joined, err)
 		}


### PR DESCRIPTION
This package is required for parsing out events from TCG and CCEL logs.