### PR TITLE
Remove Get prefixes on exported functions and interfaces

### DIFF
--- a/ccel/replay.go
+++ b/ccel/replay.go
@@ -55,5 +55,5 @@ func ReplayAndExtract(acpiTableFile []byte, rawEventLog []byte, rtmrBank registe
 	if err != nil {
 		return nil, err
 	}
-	return extract.GetFirmwareLogState(events, cryptoHash, extract.RTMRRegisterConfig, opts)
+	return extract.FirmwareLogState(events, cryptoHash, extract.RTMRRegisterConfig, opts)
 }

--- a/cel/canonical_eventlog.go
+++ b/cel/canonical_eventlog.go
@@ -128,7 +128,7 @@ type Record struct {
 // Content is a interface for the content in CELR.
 type Content interface {
 	GenerateDigest(crypto.Hash) ([]byte, error)
-	GetTLV() (TLV, error)
+	TLV() (TLV, error)
 }
 
 // CEL represents a Canonical Event Log, which contains a list of Records.
@@ -195,7 +195,7 @@ func (c *eventLog) AppendEvent(event Content, bankAlgos []crypto.Hash, mrIndex i
 		}
 	}
 
-	eventTlv, err := event.GetTLV()
+	eventTlv, err := event.TLV()
 	if err != nil {
 		return err
 	}

--- a/cel/fake_tlv.go
+++ b/cel/fake_tlv.go
@@ -27,8 +27,8 @@ type FakeTlv struct {
 	EventContent []byte
 }
 
-// GetTLV returns the TLV representation of the fake TLV.
-func (f FakeTlv) GetTLV() (TLV, error) {
+// TLV returns the TLV representation of the fake TLV.
+func (f FakeTlv) TLV() (TLV, error) {
 	data, err := TLV{uint8(f.EventType), f.EventContent}.MarshalBinary()
 	if err != nil {
 		return TLV{}, err
@@ -43,7 +43,7 @@ func (f FakeTlv) GetTLV() (TLV, error) {
 // GenerateDigest generates the digest for the given fake TLV. The whole TLV struct will
 // be marshaled to bytes and feed into the hash algo.
 func (f FakeTlv) GenerateDigest(hashAlgo crypto.Hash) ([]byte, error) {
-	contentTLV, err := f.GetTLV()
+	contentTLV, err := f.TLV()
 	if err != nil {
 		return nil, err
 	}

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -59,7 +59,7 @@ type Opts struct {
 	Loader Bootloader
 }
 
-// GetFirmwareLogState extracts event info from a verified TCG PC Client event
+// FirmwareLogState extracts event info from a verified TCG PC Client event
 // log into a FirmwareLogState.
 // It returns an error on failing to parse malformed events.
 //
@@ -70,7 +70,7 @@ type Opts struct {
 // It is the caller's responsibility to ensure that the passed events have
 // been replayed (e.g., using `tcg.ParseAndReplay`) against a verified measurement
 // register bank.
-func GetFirmwareLogState(events []tcg.Event, hash crypto.Hash, registerCfg registerConfig, opts Opts) (*pb.FirmwareLogState, error) {
+func FirmwareLogState(events []tcg.Event, hash crypto.Hash, registerCfg registerConfig, opts Opts) (*pb.FirmwareLogState, error) {
 	var joined error
 	tcgHash, err := tpm2.HashToAlgorithm(hash)
 	if err != nil {
@@ -81,11 +81,11 @@ func GetFirmwareLogState(events []tcg.Event, hash crypto.Hash, registerCfg regis
 	if err != nil {
 		joined = errors.Join(joined, err)
 	}
-	sbState, err := GetSecureBootState(events, registerCfg)
+	sbState, err := SecureBootState(events, registerCfg)
 	if err != nil {
 		joined = errors.Join(joined, err)
 	}
-	efiState, err := GetEfiState(hash, events, registerCfg)
+	efiState, err := EfiState(hash, events, registerCfg)
 
 	if err != nil {
 		joined = errors.Join(joined, err)
@@ -99,7 +99,7 @@ func GetFirmwareLogState(events []tcg.Event, hash crypto.Hash, registerCfg regis
 		if err != nil {
 			joined = errors.Join(joined, err)
 		}
-		kernel, err = GetLinuxKernelStateFromGRUB(grub)
+		kernel, err = LinuxKernelStateFromGRUB(grub)
 		if err != nil {
 			joined = errors.Join(joined, err)
 		}
@@ -200,9 +200,9 @@ func matchWellKnown(cert x509.Certificate) (pb.WellKnownCertificate, error) {
 	return pb.WellKnownCertificate_UNKNOWN, errors.New("failed to find matching well known certificate")
 }
 
-// GetSecureBootState extracts Secure Boot information from a UEFI TCG2
+// SecureBootState extracts Secure Boot information from a UEFI TCG2
 // firmware event log.
-func GetSecureBootState(replayEvents []tcg.Event, registerCfg registerConfig) (*pb.SecureBootState, error) {
+func SecureBootState(replayEvents []tcg.Event, registerCfg registerConfig) (*pb.SecureBootState, error) {
 	attestSbState, err := ParseSecurebootState(replayEvents, registerCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SecureBootState: %v", err)
@@ -218,9 +218,9 @@ func GetSecureBootState(replayEvents []tcg.Event, registerCfg registerConfig) (*
 	}, nil
 }
 
-// GetPlatformState extracts platform information from a UEFI TCG2 firmware
+// PlatformState extracts platform information from a UEFI TCG2 firmware
 // event log.
-func GetPlatformState(hash crypto.Hash, events []tcg.Event) (*pb.PlatformState, error) {
+func PlatformState(hash crypto.Hash, events []tcg.Event) (*pb.PlatformState, error) {
 	// We pre-compute the separator and EFI Action event hash.
 	// We check if these events have been modified, since the event type is
 	// untrusted.
@@ -271,9 +271,9 @@ func GetPlatformState(hash crypto.Hash, events []tcg.Event) (*pb.PlatformState, 
 	return state, nil
 }
 
-// GetEfiState extracts EFI app information from a UEFI TCG2 firmware
+// EfiState extracts EFI app information from a UEFI TCG2 firmware
 // event log.
-func GetEfiState(hash crypto.Hash, events []tcg.Event, registerCfg registerConfig) (*pb.EfiState, error) {
+func EfiState(hash crypto.Hash, events []tcg.Event, registerCfg registerConfig) (*pb.EfiState, error) {
 	// We pre-compute various event digests, and check if those event type have
 	// been modified. We only trust events that come before the
 	// ExitBootServices() request.
@@ -377,8 +377,8 @@ func GetEfiState(hash crypto.Hash, events []tcg.Event, registerCfg registerConfi
 	return nil, nil
 }
 
-// GetLinuxKernelStateFromGRUB extracts the kernel command line from GrubState.
-func GetLinuxKernelStateFromGRUB(grub *pb.GrubState) (*pb.LinuxKernelState, error) {
+// LinuxKernelStateFromGRUB extracts the kernel command line from GrubState.
+func LinuxKernelStateFromGRUB(grub *pb.GrubState) (*pb.LinuxKernelState, error) {
 	var cmdline string
 	seen := false
 

--- a/extract/extract_test.go
+++ b/extract/extract_test.go
@@ -147,7 +147,7 @@ func TestExtractFirmwareLogStateRTMR(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			evts := getCCELEvents(t)
 			tc.mutate(evts)
-			_, err := GetFirmwareLogState(evts, crypto.SHA384, RTMRRegisterConfig, Opts{Loader: GRUB})
+			_, err := FirmwareLogState(evts, crypto.SHA384, RTMRRegisterConfig, Opts{Loader: GRUB})
 			if (err != nil) != tc.expectErr {
 				t.Errorf("ExtractFirmwareLogState(%v) = got %v, wantErr: %v", tc.name, err, tc.expectErr)
 			}
@@ -156,7 +156,7 @@ func TestExtractFirmwareLogStateRTMR(t *testing.T) {
 }
 
 func TestExtractFirmwareLogStateRTMRNilEvents(t *testing.T) {
-	_, err := GetFirmwareLogState(nil, crypto.SHA384, RTMRRegisterConfig, Opts{Loader: GRUB})
+	_, err := FirmwareLogState(nil, crypto.SHA384, RTMRRegisterConfig, Opts{Loader: GRUB})
 	if err == nil || !strings.Contains(err.Error(), "no GRUB measurements found") {
 		t.Errorf("ExtractFirmwareLogState(nil): got %v, expected error no GRUB measurements found", err)
 	}
@@ -299,7 +299,7 @@ func TestExtractFirmwareLogStateTPM(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			hash, evts := getTPMELEvents(t)
 			tc.mutate(evts)
-			_, err := GetFirmwareLogState(evts, hash, TPMRegisterConfig, Opts{Loader: GRUB})
+			_, err := FirmwareLogState(evts, hash, TPMRegisterConfig, Opts{Loader: GRUB})
 			if (err != nil) != tc.expectErr {
 				t.Errorf("ExtractFirmwareLogState(%v) = got %v, wantErr: %v", tc.name, err, tc.expectErr)
 			}
@@ -308,7 +308,7 @@ func TestExtractFirmwareLogStateTPM(t *testing.T) {
 }
 
 func TestExtractFirmwareLogStateTPMNilEvents(t *testing.T) {
-	_, err := GetFirmwareLogState(nil, crypto.SHA384, TPMRegisterConfig, Opts{Loader: GRUB})
+	_, err := FirmwareLogState(nil, crypto.SHA384, TPMRegisterConfig, Opts{Loader: GRUB})
 	if err == nil || !strings.Contains(err.Error(), "no GRUB measurements found") {
 		t.Errorf("ExtractFirmwareLogState(nil): got %v, expected error no GRUB measurements found", err)
 	}

--- a/extract/pcr.go
+++ b/extract/pcr.go
@@ -25,8 +25,8 @@ import (
 	"github.com/google/go-eventlog/tcg"
 )
 
-// GetGrubStateForTPMLog extracts GRUB commands from PCR8 and GRUB files from 9.
-func GetGrubStateForTPMLog(hash crypto.Hash, events []tcg.Event) (*pb.GrubState, error) {
+// GrubStateFromTPMLog extracts GRUB commands from PCR8 and GRUB files from 9.
+func GrubStateFromTPMLog(hash crypto.Hash, events []tcg.Event) (*pb.GrubState, error) {
 	var files []*pb.GrubFile
 	var commands []string
 	for eventNum, event := range events {

--- a/extract/registerconfig.go
+++ b/extract/registerconfig.go
@@ -48,8 +48,8 @@ var TPMRegisterConfig = registerConfig{
 	ExitBootServicesIdx: 5,
 	GRUBCmdIdx:          8,
 	GRUBFileIdx:         9,
-	GRUBExtracter:       GetGrubStateForTPMLog,
-	PlatformExtracter:   GetPlatformState,
+	GRUBExtracter:       GrubStateFromTPMLog,
+	PlatformExtracter:   PlatformState,
 	// AdditionalSecureBootIdxEvents is empty since
 	// eventparse.ParseSecurebootState encodes all the current allowable types
 	// for PCR 7.
@@ -71,7 +71,7 @@ var RTMRRegisterConfig = registerConfig{
 	GRUBCmdIdx: 3,
 	// CCMR3=RTMR[2]=PCR[9]
 	GRUBFileIdx:   3,
-	GRUBExtracter: GetGrubStateForRTMRLog,
+	GRUBExtracter: GrubStateFromRTMRLog,
 	PlatformExtracter: func(_ crypto.Hash, _ []tcg.Event) (*pb.PlatformState, error) {
 		return &pb.PlatformState{Technology: pb.GCEConfidentialTechnology_INTEL_TDX}, nil
 	},

--- a/extract/rtmr.go
+++ b/extract/rtmr.go
@@ -25,8 +25,8 @@ import (
 	"github.com/google/go-eventlog/tcg"
 )
 
-// GetGrubStateForRTMRLog extracts GRUB commands from RTMR2.
-func GetGrubStateForRTMRLog(hash crypto.Hash, events []tcg.Event) (*pb.GrubState, error) {
+// GrubStateFromRTMRLog extracts GRUB commands from RTMR2.
+func GrubStateFromRTMRLog(hash crypto.Hash, events []tcg.Event) (*pb.GrubState, error) {
 	var commands []string
 	for eventNum, event := range events {
 		ccMRIndex := event.MRIndex()

--- a/register/fake_rot.go
+++ b/register/fake_rot.go
@@ -42,8 +42,8 @@ func CreateFakeRot(hashes []crypto.Hash, numIdxs int) (FakeROT, error) {
 	return FakeROT{fakeMRBanks: fakeMRBanks}, nil
 }
 
-// GetDigest returns the current digest for the given measurement register indicated by FakeMR.
-func (f FakeROT) GetDigest(mr FakeMR) ([]byte, error) {
+// Digest returns the current digest for the given measurement register indicated by FakeMR.
+func (f FakeROT) Digest(mr FakeMR) ([]byte, error) {
 	hash := mr.DigestAlg
 	idx := mr.Index
 	bank, ok := f.fakeMRBanks[hash]
@@ -92,7 +92,7 @@ func (f FakeROT) ExtendMR(mr FakeMR) error {
 		return fmt.Errorf("invalid digest size %v for algo %v, expected %v", len(digest), hash, hash.Size())
 	}
 
-	mrDigest, err := f.GetDigest(mr)
+	mrDigest, err := f.Digest(mr)
 	if err != nil {
 		return fmt.Errorf("failed to extend index %v in bank %v: %v", idx, hash, err)
 	}

--- a/tpmeventlog/replay.go
+++ b/tpmeventlog/replay.go
@@ -48,5 +48,5 @@ func ReplayAndExtract(rawEventLog []byte, pcrBank register.PCRBank, opts extract
 		return nil, err
 	}
 
-	return extract.GetFirmwareLogState(events, cryptoHash, extract.TPMRegisterConfig, opts)
+	return extract.FirmwareLogState(events, cryptoHash, extract.TPMRegisterConfig, opts)
 }


### PR DESCRIPTION
From https://github.com/GoogleCloudPlatform/confidential-space/pull/8#discussion_r1896106620.

This aligns with the Go style guide's decision on getters: https://google.github.io/styleguide/go/decisions.html#getters

This is a breaking change.