### PR TITLE
Re-Initialize PCR0 on HCRTM Event

### DIFF
--- a/tcg/eventlog_test.go
+++ b/tcg/eventlog_test.go
@@ -421,29 +421,36 @@ func TestReplayPCRSWithHCRTM(t *testing.T) {
 		},
 	}
 
-	testcases := [][]rawEvent{
+	testcases := []struct{
+		events []rawEvent
+		expectSuccess bool
+	}{
 		{
-			hcrtmEvent,
+			events: []rawEvent{hcrtmEvent},
+			expectSuccess: true,
 		},
 		{
-			{
-				// Dummy event to ensure HCRTM event clears the index.
-				sequence: 0,
-				index:    0,
-				typ:      EFIEventBase,
-				data:     []byte("testevent"),
-				digests: []digest{
-					{crypto.SHA256, decodeHex("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd")},
+			events: []rawEvent{
+				{
+					// Dummy event.
+					sequence: 0,
+					index:    0,
+					typ:      EFIEventBase,
+					data:     []byte("testevent"),
+					digests: []digest{
+						{crypto.SHA256, decodeHex("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd")},
+					},
 				},
+				hcrtmEvent,
 			},
-			hcrtmEvent,
+			expectSuccess: false,
 		},
 	}
 
 	for _, tc := range testcases {
-		_, ok := replayPCR(tc, testMR)
-		if !ok {
-			t.Errorf("replayPCR(%v, %v) failed", tc, testMR)
+		_, ok := replayPCR(tc.events, testMR)
+		if ok != tc.expectSuccess {
+			t.Errorf("replayPCR(%v, %v) returned %v, want %v", tc, testMR, ok, tc.expectSuccess)
 		}
 	}
 }

--- a/tcg/eventlog_test.go
+++ b/tcg/eventlog_test.go
@@ -391,33 +391,3 @@ YWNrLHRvbW95byxicGYgcGFuaWM9MzAgaTkxNS5lbmFibGVfcHNyPTA=`)
 		}
 	}
 }
-
-func TestIsHCRTM(t *testing.T) {
-	testcases := []struct {
-		events []rawEvent
-		index int
-		expected bool
-	}{
-		{
-			events: []rawEvent{{index: 0, typ: EFIHCRTMEvent}},
-			index: 0,
-			expected: true,
-		},
-		{
-			events: []rawEvent{{index: 0, typ: EFIEventBase}},
-			index: 0,
-			expected: false,
-		},
-		{
-			events: []rawEvent{{index: 1, typ: EFIHCRTMEvent}},
-			index: 1,
-			expected: false,
-		},
-	}
-
-	for _, tc := range testcases {
-		if got := isHCRTM(tc.events, tc.index); got != tc.expected {
-			t.Errorf("isHCRTM(%+v, %d) = %t, want %t", tc.events, tc.index, got, tc.expected)
-		}
-	}
-}

--- a/tcg/eventlog_test.go
+++ b/tcg/eventlog_test.go
@@ -406,16 +406,16 @@ func TestReplayPCRSWithHCRTM(t *testing.T) {
 
 	testDigest := "806fcb3c4d6ee3afc8eca3d420a48c206fb23803fcbd593eebba2b1df20c322c"
 	testMR := register.PCR{
-		Index: 0,
+		Index:     0,
 		DigestAlg: crypto.SHA256,
-		Digest:   decodeHex(testDigest),
+		Digest:    decodeHex(testDigest),
 	}
 
 	hcrtmEvent := rawEvent{
 		sequence: 1,
-		index: 0,
-	typ: EFIHCRTMEvent,
-		data: []byte("HCRTM"),
+		index:    0,
+		typ:      EFIHCRTMEvent,
+		data:     []byte("HCRTM"),
 		digests: []digest{
 			{crypto.SHA256, decodeHex("abababababababababababababababababababababababababababababababab")},
 		},
@@ -427,19 +427,19 @@ func TestReplayPCRSWithHCRTM(t *testing.T) {
 		},
 		{
 			{
-			// Dummy event to ensure HCRTM event clears the index.
-			sequence: 0,
-			index: 0,
-			typ: EFIEventBase,
-			data: []byte("testevent"),
-			digests: []digest{
-				{crypto.SHA256, decodeHex("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd")},
-			},
+				// Dummy event to ensure HCRTM event clears the index.
+				sequence: 0,
+				index:    0,
+				typ:      EFIEventBase,
+				data:     []byte("testevent"),
+				digests: []digest{
+					{crypto.SHA256, decodeHex("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd")},
+				},
 			},
 			hcrtmEvent,
 		},
 	}
-	
+
 	for _, tc := range testcases {
 		_, ok := replayPCR(tc, testMR)
 		if !ok {

--- a/tcg/eventlog_test.go
+++ b/tcg/eventlog_test.go
@@ -391,3 +391,37 @@ YWNrLHRvbW95byxicGYgcGFuaWM9MzAgaTkxNS5lbmFibGVfcHNyPTA=`)
 		}
 	}
 }
+
+func TestIsHCRTM(t *testing.T) {
+	testcases := []struct {
+		events []rawEvent
+		index int
+		expected bool
+	}{
+		{
+			events: []rawEvent{
+				{index: 0, typ: EFIHCRTMEvent},
+			},
+			index: 0,
+			expected: true,
+		},
+		{
+			events: []rawEvent{
+				{index: 0, typ: EFIEventBase}},
+			index: 0,
+			expected: false,
+		},
+		{
+			events: []rawEvent{
+				{index: 1, typ: EFIHCRTMEvent}},
+			index: 1,
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		if got := isHCRTM(tc.events, tc.index); got != tc.expected {
+			t.Errorf("isHCRTM(%+v, %d) = %t, want %t", tc.events, tc.index, got, tc.expected)
+		}
+	}
+}

--- a/tcg/eventlog_test.go
+++ b/tcg/eventlog_test.go
@@ -399,21 +399,17 @@ func TestIsHCRTM(t *testing.T) {
 		expected bool
 	}{
 		{
-			events: []rawEvent{
-				{index: 0, typ: EFIHCRTMEvent},
-			},
+			events: []rawEvent{{index: 0, typ: EFIHCRTMEvent}},
 			index: 0,
 			expected: true,
 		},
 		{
-			events: []rawEvent{
-				{index: 0, typ: EFIEventBase}},
+			events: []rawEvent{{index: 0, typ: EFIEventBase}},
 			index: 0,
 			expected: false,
 		},
 		{
-			events: []rawEvent{
-				{index: 1, typ: EFIHCRTMEvent}},
+			events: []rawEvent{{index: 1, typ: EFIHCRTMEvent}},
 			index: 1,
 			expected: false,
 		},

--- a/tcg/eventlog_test.go
+++ b/tcg/eventlog_test.go
@@ -421,12 +421,12 @@ func TestReplayPCRSWithHCRTM(t *testing.T) {
 		},
 	}
 
-	testcases := []struct{
-		events []rawEvent
+	testcases := []struct {
+		events        []rawEvent
 		expectSuccess bool
 	}{
 		{
-			events: []rawEvent{hcrtmEvent},
+			events:        []rawEvent{hcrtmEvent},
 			expectSuccess: true,
 		},
 		{

--- a/tcg/eventlog_test.go
+++ b/tcg/eventlog_test.go
@@ -16,7 +16,9 @@ package tcg
 
 import (
 	"bytes"
+	"crypto"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"testing"
@@ -388,6 +390,60 @@ YWNrLHRvbW95byxicGYgcGFuaWM9MzAgaTkxNS5lbmFibGVfcHNyPTA=`)
 		t.Errorf("unexpected number of events in combined log: got %d, want %d", got, want)
 		for i, e := range parsed.rawEvents {
 			t.Logf("logs[%d] = %+v", i, e)
+		}
+	}
+}
+
+func TestReplayPCRSWithHCRTM(t *testing.T) {
+	decodeHex := func(input string) []byte {
+		decoded, err := hex.DecodeString(input)
+		if err != nil {
+			t.Fatalf("Failed to hex decode %q: %v", input, err)
+		}
+
+		return decoded
+	}
+
+	testDigest := "806fcb3c4d6ee3afc8eca3d420a48c206fb23803fcbd593eebba2b1df20c322c"
+	testMR := register.PCR{
+		Index: 0,
+		DigestAlg: crypto.SHA256,
+		Digest:   decodeHex(testDigest),
+	}
+
+	hcrtmEvent := rawEvent{
+		sequence: 1,
+		index: 0,
+	typ: EFIHCRTMEvent,
+		data: []byte("HCRTM"),
+		digests: []digest{
+			{crypto.SHA256, decodeHex("abababababababababababababababababababababababababababababababab")},
+		},
+	}
+
+	testcases := [][]rawEvent{
+		{
+			hcrtmEvent,
+		},
+		{
+			{
+			// Dummy event to ensure HCRTM event clears the index.
+			sequence: 0,
+			index: 0,
+			typ: EFIEventBase,
+			data: []byte("testevent"),
+			digests: []digest{
+				{crypto.SHA256, decodeHex("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd")},
+			},
+			},
+			hcrtmEvent,
+		},
+	}
+	
+	for _, tc := range testcases {
+		_, ok := replayPCR(tc, testMR)
+		if !ok {
+			t.Errorf("replayPCR(%v, %v) failed", tc, testMR)
 		}
 	}
 }

--- a/tcg/pfpformat.go
+++ b/tcg/pfpformat.go
@@ -355,6 +355,20 @@ func extend(pcr register.MR, replay []byte, e rawEvent, locality byte) (pcrDiges
 	return nil, nil, fmt.Errorf("no event digest matches pcr algorithm: %v", pcr.DgstAlg())
 }
 
+// Returns whether this is a HCRTM register.
+func isHCRTM(events []rawEvent, index int) bool {
+	if index != 0 {
+		return false
+	}
+	for _, e := range events {
+		if e.typ == EFIHCRTMEvent {
+			return true
+		}
+	}
+
+	return false
+}
+
 // replayPCR replays the event log for a specific PCR, using pcr and
 // event digests with the algorithm in pcr. An error is returned if the
 // replayed values do not match the final PCR digest, or any event tagged
@@ -365,7 +379,13 @@ func replayPCR(rawEvents []rawEvent, mr register.MR) ([]Event, bool) {
 		outEvents []Event
 		locality  byte
 	)
+
 	mrIdx := mr.Idx()
+
+	if isHCRTM(rawEvents, mrIdx) {
+		replay = append(bytes.Repeat([]byte{0x00}, mr.DgstAlg().Size()-1), byte(0x04))
+	}
+
 	for _, e := range rawEvents {
 		if e.index != mrIdx {
 			continue

--- a/tcg/pfpformat.go
+++ b/tcg/pfpformat.go
@@ -355,20 +355,6 @@ func extend(pcr register.MR, replay []byte, e rawEvent, locality byte) (pcrDiges
 	return nil, nil, fmt.Errorf("no event digest matches pcr algorithm: %v", pcr.DgstAlg())
 }
 
-// Returns whether this is a HCRTM register.
-func isHCRTM(events []rawEvent, index int) bool {
-	if index != 0 {
-		return false
-	}
-	for _, e := range events {
-		if e.typ == EFIHCRTMEvent {
-			return true
-		}
-	}
-
-	return false
-}
-
 // replayPCR replays the event log for a specific PCR, using pcr and
 // event digests with the algorithm in pcr. An error is returned if the
 // replayed values do not match the final PCR digest, or any event tagged
@@ -379,13 +365,7 @@ func replayPCR(rawEvents []rawEvent, mr register.MR) ([]Event, bool) {
 		outEvents []Event
 		locality  byte
 	)
-
 	mrIdx := mr.Idx()
-
-	if isHCRTM(rawEvents, mrIdx) {
-		replay = append(bytes.Repeat([]byte{0x00}, mr.DgstAlg().Size()-1), byte(0x04))
-	}
-
 	for _, e := range rawEvents {
 		if e.index != mrIdx {
 			continue
@@ -401,6 +381,12 @@ func replayPCR(rawEvents []rawEvent, mr register.MR) ([]Event, bool) {
 			}
 			continue
 		}
+
+		// HCRTM resets the PCR to {0, ... 0, 4} prior to extending.
+		if e.typ == EFIHCRTMEvent {
+			replay = append(bytes.Repeat([]byte{0x00}, mr.DgstAlg().Size()-1), byte(0x04))
+		}
+
 		replayValue, digest, err := extend(mr, replay, e, locality)
 		if err != nil {
 			return nil, false

--- a/tcg/pfpformat.go
+++ b/tcg/pfpformat.go
@@ -382,8 +382,13 @@ func replayPCR(rawEvents []rawEvent, mr register.MR) ([]Event, bool) {
 			continue
 		}
 
-		// HCRTM resets the PCR to {0, ... 0, 4} prior to extending.
 		if e.typ == EFIHCRTMEvent {
+			// Expect HCRTM to be the first event in the register.
+			if len(replay) != 0 {
+				return nil, false
+			}
+
+			// HCRTM resets the PCR to {0, ... 0, 4} prior to extending.
 			replay = append(bytes.Repeat([]byte{0x00}, mr.DgstAlg().Size()-1), byte(0x04))
 		}
 


### PR DESCRIPTION
For HCRTM, PCR0 is initialized to {0, ..., 0, 4} before extending. According to the spec [here](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf), "The value 0…4 represents evidence that the initial measurement was from an H-CRTM."

This adjusts replay logic to do the same if an HCRTM event type is detected.