### PR TITLE
cel: add bounds check in unmarshalFirstTLV to prevent OOM DoS

### DIFF
--- a/cel/canonical_eventlog.go
+++ b/cel/canonical_eventlog.go
@@ -38,6 +38,12 @@ const (
 
 	recnumValueLength   uint32 = 8 // support up to 2^64 records
 	regIndexValueLength uint32 = 1 // support up to 256 registers
+
+	// maxTLVValueSize caps the allocation in unmarshalFirstTLV to prevent an
+	// out-of-memory condition when parsing attacker-controlled CEL data.
+	// The largest legitimate TLV value in a CEL record is the content field,
+	// which is bounded well below 1 MiB in practice.
+	maxTLVValueSize uint32 = 1 << 20 // 1 MiB
 )
 
 // MRExtender extends an implementation-specific measurement register at the
@@ -96,6 +102,9 @@ func unmarshalFirstTLV(buf *bytes.Buffer) (tlv TLV, err error) {
 		return TLV{}, io.EOF
 	}
 	valueLength := binary.BigEndian.Uint32(lengthBytes)
+	if valueLength > maxTLVValueSize {
+		return TLV{}, fmt.Errorf("TLV value length %d exceeds maximum %d", valueLength, maxTLVValueSize)
+	}
 	data = append(data, lengthBytes...)
 
 	valueBytes := make([]byte, valueLength)

--- a/cel/canonical_eventlog_test.go
+++ b/cel/canonical_eventlog_test.go
@@ -255,3 +255,24 @@ func fakeRotExtender(rot register.FakeROT) MRExtender {
 		})
 	}
 }
+
+// TestOversizeTLVValueLength is a regression test for a pre-fix OOM condition:
+// unmarshalFirstTLV allocated make([]byte, valueLength) without any bounds check,
+// allowing a 5-byte crafted TLV (1 type byte + 4-byte uint32 length) to trigger
+// a multi-gigabyte allocation. The fix adds the maxTLVValueSize guard.
+func TestOversizeTLVValueLength(t *testing.T) {
+	// 5-byte crafted TLV: type=0x00, length=maxTLVValueSize+1, no value bytes.
+	var buf bytes.Buffer
+	buf.WriteByte(0x00) // recnum type
+	oversize := maxTLVValueSize + 1
+	buf.WriteByte(byte(oversize >> 24))
+	buf.WriteByte(byte(oversize >> 16))
+	buf.WriteByte(byte(oversize >> 8))
+	buf.WriteByte(byte(oversize))
+
+	_, err := unmarshalFirstTLV(&buf)
+	if err == nil {
+		t.Fatal("unmarshalFirstTLV should return an error for oversize valueLength")
+	}
+	t.Logf("correctly rejected oversize TLV: %v", err)
+}


### PR DESCRIPTION
## Summary

`unmarshalFirstTLV` in `cel/canonical_eventlog.go` reads a `uint32` value length
from the input buffer and passes it directly to `make([]byte, valueLength)` with no
bounds check. A crafted 5-byte TLV (`[type][0xFF 0xFF 0xFF 0xFF]`) causes a
4 GiB allocation attempt, crashing any process that parses untrusted CEL data.

### Root cause

```go
valueLength := binary.BigEndian.Uint32(lengthBytes)  // raw uint32, no check
// ...
valueBytes := make([]byte, valueLength)              // ← up to 4 GiB
```

### Impact

Any caller of `DecodeToCEL` or `unmarshalDigests` that processes attacker-supplied
CEL bytes is vulnerable. Concretely, attestation verifiers that parse Confidential
VM event logs (e.g. go-tpm-tools `server.VerifyAttestation`) receive the event log
from the client VM — making this reachable from untrusted input.

### Fix

Add `maxTLVValueSize = 1<<20` (1 MiB) and reject oversized lengths before
allocating:

```go
if valueLength > maxTLVValueSize {
    return TLV{}, fmt.Errorf("TLV value length %d exceeds maximum %d", valueLength, maxTLVValueSize)
}
```

The cap is generous: the fixed CEL fields (recnum = 8 B, regIndex = 1 B) and digest
TLVs (a few hundred bytes) are well below this limit. Even custom content events are
unlikely to approach 1 MiB in practice.

### Test

`TestOversizeTLVValueLength` (added to `cel/canonical_eventlog_test.go`) crafts a
5-byte TLV with `valueLength = maxTLVValueSize+1` and asserts that `unmarshalFirstTLV`
returns an error without performing a large allocation.