### PR TITLE
Fix infinite recursion bug in event.UntrustedType

### DIFF
--- a/tcg/pfpformat.go
+++ b/tcg/pfpformat.go
@@ -88,7 +88,7 @@ func (e Event) MRIndex() uint32 {
 func (e Event) UntrustedType() EventType {
 	tcgEvent := EventType(e.Type)
 	if _, ok := tcgEvent.KnownName(); !ok {
-		panic("library cannot convert between tpmeventlog EventType and tcg EventType for event " + e.UntrustedType().String())
+		panic("library cannot convert between tpmeventlog EventType and tcg EventType for event " + e.Type.String())
 	}
 	return tcgEvent
 }


### PR DESCRIPTION
If the panic in `Event.UntrustedType` is encountered, it results in an infinite recursion as it attempts to call itself to populate the panic message. Fix is to use `Event.Type.String()` instead.