### PR TITLE
Remove MBM event from GMESState

### DIFF
--- a/extract/extract.go
+++ b/extract/extract.go
@@ -521,7 +521,6 @@ func GMESState(hash crypto.Hash, events []tcg.Event) (*pb.GMESState, error) {
 	state := &pb.GMESState{}
 	seenSeparators := map[uint32]bool{
 		gmes.PCRConfig.BMCFirmwareIdx: false,
-		gmes.PCRConfig.MBMIdx:         false,
 		gmes.PCRConfig.BIOSIdx:        false,
 		gmes.PCRConfig.HostKernelIdx:  false,
 	}
@@ -586,9 +585,6 @@ func GMESState(hash crypto.Hash, events []tcg.Event) (*pb.GMESState, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed parsing EFI image load at host kernel event %d: %v", event.Num(), err)
 			}
-
-		case registerCfg.MBMIdx:
-			continue
 
 		default:
 			return nil, fmt.Errorf("unknown MR index: %d", event.MRIndex())

--- a/extract/extract_test.go
+++ b/extract/extract_test.go
@@ -682,7 +682,6 @@ func TestGMESState(t *testing.T) {
 		newSeparatorEvent(t, gmes.PCRConfig.BMCFirmwareIdx),
 		newSeparatorEvent(t, gmes.PCRConfig.BIOSIdx),
 		newSeparatorEvent(t, gmes.PCRConfig.HostKernelIdx),
-		newSeparatorEvent(t, gmes.PCRConfig.MBMIdx),
 	}
 
 	bmcEvent := newEvent(t, gmes.PCRConfig.BMCFirmwareIdx, tcg.EFIHCRTMEvent, []byte(gmes.BMCData))
@@ -693,8 +692,6 @@ func TestGMESState(t *testing.T) {
 		bmcEvent,
 		biosEvent,
 		kernelEvent,
-		// MBM data is not captured in GMESState but we should ensure it's handled correctly.
-		newEvent(t, gmes.PCRConfig.MBMIdx, tcg.EventTag, []byte("please ignore me!")),
 	}, separatorEvents...)
 
 	// We need to ensure events are replayed correctly.
@@ -721,15 +718,12 @@ func TestGMESStateErrors(t *testing.T) {
 		newSeparatorEvent(t, gmes.PCRConfig.BMCFirmwareIdx),
 		newSeparatorEvent(t, gmes.PCRConfig.BIOSIdx),
 		newSeparatorEvent(t, gmes.PCRConfig.HostKernelIdx),
-		newSeparatorEvent(t, gmes.PCRConfig.MBMIdx),
 	}
 
 	validEvents := append([]tcg.Event{
 		newEvent(t, gmes.PCRConfig.BMCFirmwareIdx, tcg.EFIHCRTMEvent, []byte(gmes.BMCData)),
 		newEvent(t, gmes.PCRConfig.BIOSIdx, tcg.GoogleDRTMEvent, []byte(gmes.BIOSData)),
 		newEFIImageLoadEvent(t, gmes.PCRConfig.HostKernelIdx, 0x1000, 0x2000, 0x3000, []byte("test-dev-path")),
-		// MBM data is not captured in GMESState but we should ensure it's handled correctly.
-		newEvent(t, gmes.PCRConfig.MBMIdx, tcg.EventTag, []byte("please ignore me!")),
 	}, separatorEvents...)
 
 	testcases := []struct {

--- a/extract/gmes/gmes.go
+++ b/extract/gmes/gmes.go
@@ -25,7 +25,6 @@ const (
 
 type registerConfig struct {
 	BMCFirmwareIdx uint32
-	MBMIdx         uint32
 	BIOSIdx        uint32
 	HostKernelIdx  uint32
 }
@@ -33,7 +32,6 @@ type registerConfig struct {
 // PCRConfig configures the expected PCR indexes for GMES event logs.
 var PCRConfig = registerConfig{
 	BMCFirmwareIdx: 0,
-	MBMIdx:         11,
 	BIOSIdx:        17,
 	HostKernelIdx:  21,
 }


### PR DESCRIPTION
MBM does not need to be quoted, so it should be removed from the verification/parsing code.