### PR TITLE
tcg: skip SignatureHeader vendor bytes in parseEfiSignatureList (hash injection)

### DIFF
--- a/tcg/efi_signature_list_test.go
+++ b/tcg/efi_signature_list_test.go
@@ -1,0 +1,46 @@
+package tcg
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func pocGuidBytes(g efiGUID) []byte {
+	b := new(bytes.Buffer)
+	binary.Write(b, binary.LittleEndian, g)
+	return b.Bytes()
+}
+
+func pocBuildSigList(sigType efiGUID, listSize, hdrSize, sigSize uint32, body []byte) []byte {
+	b := new(bytes.Buffer)
+	b.Write(pocGuidBytes(sigType))
+	binary.Write(b, binary.LittleEndian, listSize)
+	binary.Write(b, binary.LittleEndian, hdrSize)
+	binary.Write(b, binary.LittleEndian, sigSize)
+	b.Write(body)
+	return b.Bytes()
+}
+
+// Regression test for the EFI signature-list hash injection (GHSA-9r4w-jg96-92mv class):
+// the SignatureHeaderSize vendor bytes between the fixed header and the signature entries
+// must be skipped, not parsed as EFI_SIGNATURE_DATA. Before the fix, a list with zero real
+// entries but attacker-chosen vendor bytes made SignatureData() return those bytes as a
+// trusted SHA256 db/dbx hash. After the fix, the malformed list must be rejected (or yield
+// no entries) and the injected bytes must never appear as a trusted hash.
+func TestEfiSignatureList_NoHashInjectionFromVendorHeader(t *testing.T) {
+	owner := bytes.Repeat([]byte{0xAA}, 16)
+	injected := bytes.Repeat([]byte{0x41}, 32) // attacker-chosen "trusted" SHA256 hash
+	vendor := append(append([]byte{}, owner...), injected...)
+	listSize := uint32(28 + len(vendor)) // header + vendor bytes; ZERO real signature entries
+	data := pocBuildSigList(hashSHA256SigGUID, listSize, uint32(len(vendor)), 48, vendor)
+
+	v := &UEFIVariableData{VariableData: data}
+	_, hashes, err := v.SignatureData()
+	t.Logf("err=%v hashes=%d", err, len(hashes))
+	for _, h := range hashes {
+		if bytes.Equal(h, injected) {
+			t.Fatalf("hash injection: vendor-header bytes were accepted as a trusted db/dbx hash (%x)", h)
+		}
+	}
+}

--- a/tcg/events.go
+++ b/tcg/events.go
@@ -471,11 +471,38 @@ func parseEfiSignatureList(b []byte) ([]x509.Certificate, [][]byte, error) {
 		if signatures.Header.SignatureListSize > maxDataLen {
 			return nil, nil, fmt.Errorf("signature list too large: %d > %d", signatures.Header.SignatureListSize, maxDataLen)
 		}
+		// Guard against uint32 underflow / OOM / hash injection: SignatureListSize,
+		// SignatureSize and SignatureHeaderSize are attacker-controlled. Without these
+		// checks the subtractions below (SignatureListSize-28, SignatureSize-16) wrap
+		// around (infinite loop / ~4 GiB make([]byte, ...)), and the vendor
+		// SignatureHeader bytes are misread as signature entries, allowing a crafted
+		// event log to inject arbitrary hashes/certs into the trusted db/dbx list.
+		// Mirrors the fix in google/go-attestation (GHSA-9r4w-jg96-92mv); per UEFI
+		// spec section 31.4.1 the SignatureHeaderSize vendor bytes appear between the
+		// fixed header and the signature entries and MUST be skipped.
+		if signatures.Header.SignatureListSize < 28 {
+			return nil, nil, fmt.Errorf("SignatureListSize %d is smaller than the minimum header size of 28", signatures.Header.SignatureListSize)
+		}
+		if signatures.Header.SignatureSize < 16 {
+			return nil, nil, fmt.Errorf("SignatureSize %d is smaller than the minimum entry size of 16", signatures.Header.SignatureSize)
+		}
+		remainingListSize := signatures.Header.SignatureListSize - 28
+		if signatures.Header.SignatureSize > remainingListSize {
+			return nil, nil, fmt.Errorf("SignatureSize %d exceeds remaining signature list space %d", signatures.Header.SignatureSize, remainingListSize)
+		}
+		if signatures.Header.SignatureHeaderSize >= remainingListSize {
+			return nil, nil, fmt.Errorf("SignatureHeaderSize %d exceeds remaining signature list space %d", signatures.Header.SignatureHeaderSize, remainingListSize)
+		}
+		if signatures.Header.SignatureHeaderSize > 0 {
+			if _, err := buf.Seek(int64(signatures.Header.SignatureHeaderSize), io.SeekCurrent); err != nil {
+				return nil, nil, fmt.Errorf("seeking past signature vendor header: %w", err)
+			}
+		}
 
 		signatureType := signatures.Header.SignatureType
 		switch signatureType {
 		case certX509SigGUID: // X509 certificate
-			for sigOffset := 0; uint32(sigOffset) < signatures.Header.SignatureListSize-28; {
+			for sigOffset := int(signatures.Header.SignatureHeaderSize); uint32(sigOffset) < signatures.Header.SignatureListSize-28; {
 				signature := efiSignatureData{}
 				signature.SignatureData = make([]byte, signatures.Header.SignatureSize-16)
 				err := binary.Read(buf, binary.LittleEndian, &signature.SignatureOwner)
@@ -494,7 +521,7 @@ func parseEfiSignatureList(b []byte) ([]x509.Certificate, [][]byte, error) {
 				certificates = append(certificates, *cert)
 			}
 		case hashSHA256SigGUID: // SHA256
-			for sigOffset := 0; uint32(sigOffset) < signatures.Header.SignatureListSize-28; {
+			for sigOffset := int(signatures.Header.SignatureHeaderSize); uint32(sigOffset) < signatures.Header.SignatureListSize-28; {
 				signature := efiSignatureData{}
 				signature.SignatureData = make([]byte, signatures.Header.SignatureSize-16)
 				err := binary.Read(buf, binary.LittleEndian, &signature.SignatureOwner)


### PR DESCRIPTION
## What

`parseEfiSignatureList` (`tcg/events.go`) iterated `EFI_SIGNATURE_DATA` entries starting at `sigOffset := 0` instead of `SignatureHeaderSize`, and never skipped the vendor `SignatureHeader` bytes. Per the UEFI spec (§31.4.1), `SignatureHeaderSize` bytes of vendor data sit between the fixed list header and the actual signature entries and must be skipped.

As a result, a crafted `EFI_SIGNATURE_LIST` with **zero real entries** but attacker-chosen vendor-header bytes has those bytes misread as `EFI_SIGNATURE_DATA` entries. Through the exported `UEFIVariableData.SignatureData()` — which `extract/secureboot.go` calls for `PK`/`KEK`/`db`/`dbx` while building `SecureBootState` from an attestation event log — this injects attacker-chosen hashes/certs into the **trusted** secure-boot signature database. The event log is attacker-controlled attestation evidence (e.g. a confidential-VM guest's own CCEL + RTMR), so a malicious attester can make the verifier accept a forged secure-boot db/dbx and still return success.

Minimal reproduction (a list whose only content is a 16-byte owner GUID + a 32-byte attacker hash, declared entirely as the vendor header):

```go
v := &UEFIVariableData{VariableData: data}
_, hashes, err := v.SignatureData()
// before this fix: err == nil and hashes == [4141...41]
//   — a "trusted" SHA256 db/dbx hash that was never a real signature entry
```

The missing `SignatureSize - 16` / `SignatureListSize - 28` lower-bound guards additionally allow `uint32` underflow (infinite loop, or a ~4 GiB `make([]byte, ...)`).

## Why

This is the same defect — and the same fix — as **GHSA-9r4w-jg96-92mv** in `google/go-attestation`, whose copy of `parseEfiSignatureList` received these guards in PRs #502 / #486 / #500. This repository forked the pre-patch version of the function and never picked them up. (`go-attestation`'s patched loop is `for sigOffset := int(SignatureHeaderSize); ...` with a `SignatureHeaderSize >= remainingListSize` guard and a `buf.Seek(SignatureHeaderSize)`; this fork still had `for sigOffset := 0; ...` with none. The sibling parser `parseDevicePathElement` in this same file *does* have a lower-bound guard, so the omission here is a genuine gap.)

## Fix

Port the guards: reject `SignatureListSize < 28`, `SignatureSize < 16`, and `SignatureSize` / `SignatureHeaderSize` exceeding the remaining list space; `Seek` past the vendor header; and start both entry loops at `SignatureHeaderSize`. Adds a regression test asserting the vendor bytes are no longer returned as a trusted hash.

## Testing

`go test ./tcg/... ./extract/...` passes (existing real-event-log tests unaffected), plus the new regression test.
