### PR TITLE
Replace GMESState Separator checks with single-event checks

### DIFF
--- a/extract/extract.go
+++ b/extract/extract.go
@@ -519,9 +519,15 @@ func getGrubKernelCmdlineSuffix(grubCmd []byte) int {
 // GMESState extracts Google Measurement Event Structure (GMES) information from a TCG event log.
 func GMESState(hash crypto.Hash, events []tcg.Event) (*pb.GMESState, error) {
 	state := &pb.GMESState{}
-	seenSeparators := map[uint32]bool{
+
+	// Track seen events for PCRs expecting only one event.
+	seenEvents := map[uint32]bool{
 		gmes.PCRConfig.BMCFirmwareIdx: false,
 		gmes.PCRConfig.BIOSIdx:        false,
+	}
+
+	// Track seen separators for PCRs requiring a separator.
+	seenSeparators := map[uint32]bool{
 		gmes.PCRConfig.HostKernelIdx:  false,
 	}
 
@@ -534,11 +540,7 @@ func GMESState(hash crypto.Hash, events []tcg.Event) (*pb.GMESState, error) {
 		// Handle separator types.
 		if eventType == tcg.Separator {
 			seen, ok := seenSeparators[event.MRIndex()]
-			if !ok { // Skip if not a GMES index.
-				continue
-			}
-
-			if seen {
+			if ok && seen {
 				return nil, fmt.Errorf("duplicate separator event at MR%d", event.MRIndex())
 			}
 
@@ -556,6 +558,12 @@ func GMESState(hash crypto.Hash, events []tcg.Event) (*pb.GMESState, error) {
 			continue
 		}
 
+		// Check for seen events.
+		if seen, ok := seenEvents[event.MRIndex()]; ok && seen{
+			return nil, fmt.Errorf("found duplicate event for MR%d at event %d, expect only one event in register", event.MRIndex(), event.Num())
+		}
+
+		// Check for seen separators.
 		if seen, ok := seenSeparators[event.MRIndex()]; ok && seen {
 			return nil, fmt.Errorf("found event after separator for MR%d at event %d", event.MRIndex(), event.Num())
 		}
@@ -563,12 +571,14 @@ func GMESState(hash crypto.Hash, events []tcg.Event) (*pb.GMESState, error) {
 		registerCfg := gmes.PCRConfig
 		switch event.MRIndex() {
 		case registerCfg.BMCFirmwareIdx:
+			seenEvents[event.MRIndex()] = true
 			if eventType != tcg.EFIHCRTMEvent {
 				return nil, fmt.Errorf("unexpected event type for BMC firmware event: %d", eventType)
 			}
 			state.BmcFirmwareDigest = event.ReplayedDigest()
 
 		case registerCfg.BIOSIdx:
+			seenEvents[event.MRIndex()] = true
 			if eventType != tcg.GoogleDRTMEvent {
 				return nil, fmt.Errorf("unexpected event type for BIOS event: %d", eventType)
 			}
@@ -580,7 +590,7 @@ func GMESState(hash crypto.Hash, events []tcg.Event) (*pb.GMESState, error) {
 			}
 			state.HostKernelDigest = event.ReplayedDigest()
 
-			// Parse & populate image load event.
+			// Parse image load event.
 			_, err := tcg.ParseEFIImageLoad(bytes.NewReader(event.RawData()))
 			if err != nil {
 				return nil, fmt.Errorf("failed parsing EFI image load at host kernel event %d: %v", event.Num(), err)

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -559,7 +559,7 @@ func GMESState(hash crypto.Hash, events []tcg.Event) (*pb.GMESState, error) {
 		}
 
 		// Check for seen events.
-		if seen, ok := seenEvents[event.MRIndex()]; ok && seen{
+		if seen, ok := seenEvents[event.MRIndex()]; ok && seen {
 			return nil, fmt.Errorf("found duplicate event for MR%d at event %d, expect only one event in register", event.MRIndex(), event.Num())
 		}
 

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -528,7 +528,7 @@ func GMESState(hash crypto.Hash, events []tcg.Event) (*pb.GMESState, error) {
 
 	// Track seen separators for PCRs requiring a separator.
 	seenSeparators := map[uint32]bool{
-		gmes.PCRConfig.HostKernelIdx:  false,
+		gmes.PCRConfig.HostKernelIdx: false,
 	}
 
 	for _, event := range events {

--- a/extract/extract_test.go
+++ b/extract/extract_test.go
@@ -714,17 +714,13 @@ func TestGMESState(t *testing.T) {
 }
 
 func TestGMESStateErrors(t *testing.T) {
-	separatorEvents := []tcg.Event{
-		newSeparatorEvent(t, gmes.PCRConfig.BMCFirmwareIdx),
-		newSeparatorEvent(t, gmes.PCRConfig.BIOSIdx),
-		newSeparatorEvent(t, gmes.PCRConfig.HostKernelIdx),
-	}
-
-	validEvents := append([]tcg.Event{
+	separatorEvent := newSeparatorEvent(t, gmes.PCRConfig.HostKernelIdx)
+	validEvents := []tcg.Event{
 		newEvent(t, gmes.PCRConfig.BMCFirmwareIdx, tcg.EFIHCRTMEvent, []byte(gmes.BMCData)),
 		newEvent(t, gmes.PCRConfig.BIOSIdx, tcg.GoogleDRTMEvent, []byte(gmes.BIOSData)),
 		newEFIImageLoadEvent(t, gmes.PCRConfig.HostKernelIdx, 0x1000, 0x2000, 0x3000, []byte("test-dev-path")),
-	}, separatorEvents...)
+		separatorEvent,
+	}
 
 	testcases := []struct {
 		name           string
@@ -733,7 +729,7 @@ func TestGMESStateErrors(t *testing.T) {
 	}{
 		{
 			name:           "duplicate separator",
-			events:         append(validEvents, newSeparatorEvent(t, gmes.PCRConfig.BMCFirmwareIdx)),
+			events:         append(validEvents, newSeparatorEvent(t, gmes.PCRConfig.HostKernelIdx)),
 			expectedErrStr: "duplicate separator event",
 		},
 		{
@@ -745,40 +741,59 @@ func TestGMESStateErrors(t *testing.T) {
 		},
 		{
 			name: "invalid BMC event type",
-			events: append([]tcg.Event{
+			events: []tcg.Event{
 				newEvent(t, gmes.PCRConfig.BMCFirmwareIdx, tcg.GoogleDRTMEvent, []byte(gmes.BMCData)),
-			}, separatorEvents...),
+				separatorEvent,
+			},
 			expectedErrStr: "unexpected event type for BMC firmware",
 		},
 		{
 			name: "invalid BIOS event type",
-			events: append([]tcg.Event{
+			events: []tcg.Event{
 				newEvent(t, gmes.PCRConfig.BIOSIdx, tcg.EFIHCRTMEvent, []byte(gmes.BIOSData)),
-			}, separatorEvents...),
+				separatorEvent,
+			},
 			expectedErrStr: "unexpected event type for BIOS",
 		},
 		{
 			name: "invalid Host Kernel event type",
-			events: append([]tcg.Event{
+			events: []tcg.Event{
 				newEvent(t, gmes.PCRConfig.HostKernelIdx, tcg.GoogleDRTMEvent, []byte("testhostkernel")),
-				newSeparatorEvent(t, gmes.PCRConfig.HostKernelIdx),
-			}, separatorEvents...),
+				separatorEvent,
+			},
 			expectedErrStr: "unexpected event type for host kernel",
 		},
 		{
 			name: "unknown MR index",
-			events: append([]tcg.Event{
+			events: []tcg.Event{
 				newEvent(t, 999, tcg.EFIHCRTMEvent, []byte("unknown data")),
-			}, separatorEvents...),
+				separatorEvent,
+			},
 			expectedErrStr: "unknown MR index",
 		},
 		{
-			name: "missing separators",
+			name: "missing separator",
 			events: []tcg.Event{
 				newEvent(t, gmes.PCRConfig.BMCFirmwareIdx, tcg.EFIHCRTMEvent, []byte(gmes.BMCData)),
 				newEvent(t, gmes.PCRConfig.BIOSIdx, tcg.GoogleDRTMEvent, []byte(gmes.BIOSData)),
 			},
 			expectedErrStr: "missing separator event",
+		},
+		{
+			name: "extra BMC event",
+			events: append(
+				validEvents,
+				newEvent(t, gmes.PCRConfig.BMCFirmwareIdx, tcg.GoogleDRTMEvent, []byte(gmes.BMCData)),
+			),
+			expectedErrStr: "found duplicate event for MR",
+		},
+		{
+			name: "extra BIOS event",
+			events: append(
+				validEvents,
+				newEvent(t, gmes.PCRConfig.BIOSIdx, tcg.GoogleDRTMEvent, []byte(gmes.BIOSData)),
+			),
+			expectedErrStr: "found duplicate event for MR",
 		},
 	}
 

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -222,9 +222,14 @@ message FirmwareLogState {
 
 // The verified state of Google measurements on the machine.
 message GMESState {
+  // Digest of the BMC firmware digest.
+  // The double digest is due to the measurement being a digest, which is hashed again when extended.
   bytes bmc_firmware_digest = 1;
 
+  // Digest of the BIOS digest.
+  // The double digest is due to the measurement being a digest, which is hashed again when extended.
   bytes bios_digest = 2;
 
+  // Digest of the host kernel.
   bytes host_kernel_digest = 3;
 }

--- a/proto/state/state.pb.go
+++ b/proto/state/state.pb.go
@@ -1183,9 +1183,14 @@ type GMESState struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// Digest of the BMC firmware digest.
+	// The double digest is due to the measurement being a digest, which is hashed again when extended.
 	BmcFirmwareDigest []byte `protobuf:"bytes,1,opt,name=bmc_firmware_digest,json=bmcFirmwareDigest,proto3" json:"bmc_firmware_digest,omitempty"`
-	BiosDigest        []byte `protobuf:"bytes,2,opt,name=bios_digest,json=biosDigest,proto3" json:"bios_digest,omitempty"`
-	HostKernelDigest  []byte `protobuf:"bytes,3,opt,name=host_kernel_digest,json=hostKernelDigest,proto3" json:"host_kernel_digest,omitempty"`
+	// Digest of the BIOS digest.
+	// The double digest is due to the measurement being a digest, which is hashed again when extended.
+	BiosDigest []byte `protobuf:"bytes,2,opt,name=bios_digest,json=biosDigest,proto3" json:"bios_digest,omitempty"`
+	// Digest of the host kernel.
+	HostKernelDigest []byte `protobuf:"bytes,3,opt,name=host_kernel_digest,json=hostKernelDigest,proto3" json:"host_kernel_digest,omitempty"`
 }
 
 func (x *GMESState) Reset() {


### PR DESCRIPTION
Due to limitations on PCRs 0 and 17, the separator checks are replaced with checks for a single event in each of them. HostACOSState field comments are also clarified to note which measurements are double-hashed.